### PR TITLE
testcases: add array packing/alignment test case

### DIFF
--- a/testcases.xml
+++ b/testcases.xml
@@ -8,9 +8,11 @@
     <!-- Testing encoding, plus __type-less should become string -->
     <superstar babe="ミツル">シ　イス　マイ　ワイフ</superstar>
     <!-- Testing 6bit conversion -->
-    <xXx_T4GG3R_xXx __type="3u8">8 9 10</xXx_T4GG3R_xXx>
-    <!-- Shouldn't have alignment issues from the 3u8 -->
+    <xXx_T4GG3R_xXx __type="2u8">8 9</xXx_T4GG3R_xXx>
+    <!-- Shouldn't have alignment issues from the 2u8 -->
     <aligned __type="u8">12</aligned>
+    <!-- Array contents are never packed -->
+    <aligned_arr __type="u8" __count="1">13</aligned_arr>
     <!-- Binary parsing -->
     <entry __type="binary">DEADBEEF</entry>
     <!-- Lowercase, too -->

--- a/testcases_out.xml
+++ b/testcases_out.xml
@@ -3,8 +3,9 @@
   <entry __type="ip4" __count="2">127.0.0.1 192.168.0.1</entry>
   <entry __type="str" attr="test" attr2="best">Hello, world!</entry>
   <superstar __type="str" babe="ミツル">シ　イス　マイ　ワイフ</superstar>
-  <xXx_T4GG3R_xXx __type="3u8">8 9 10</xXx_T4GG3R_xXx>
+  <xXx_T4GG3R_xXx __type="2u8">8 9</xXx_T4GG3R_xXx>
   <aligned __type="u8">12</aligned>
+  <aligned_arr __type="u8" __count="1">13</aligned_arr>
   <entry __type="bin" __size="4">deadbeef</entry>
   <entry __type="bin" __size="4">deadbe7a</entry>
   <entry __type="3u8" __count="2">1 2 3 1 2 3</entry>


### PR DESCRIPTION
Array reads are never taken from the packed buffers, even if the total array size would easily fit in them.